### PR TITLE
OHTTP: Send authorization header on relay request

### DIFF
--- a/src/lib/utils/ohttpHelpers.ts
+++ b/src/lib/utils/ohttpHelpers.ts
@@ -285,7 +285,9 @@ export const encryptedHttpRequest = async (relayUrl: string, keysInfo: HpkeConfi
 
 	const res2 = await fetch(relayUrl, {
 		method: 'POST',
-		headers: { 'Content-Type': 'message/ohttp-req' },
+		headers: { 'Content-Type': 'message/ohttp-req',
+			'Authorization': 'Bearer ' + JSON.parse(sessionStorage.getItem('appToken'))
+		},
 		body: toArrayBuffer(encapsulatedRequest) as ArrayBuffer,
 	});
 


### PR DESCRIPTION
Required for https://github.com/gunet/funke-s3a-wallet-ecosystem/pull/15

- Added Authorization header on relay requests (similar to classic proxy requests)