### PR TITLE
Fix type error about HTTP headers

### DIFF
--- a/src/lib/utils/bhttp.ts
+++ b/src/lib/utils/bhttp.ts
@@ -1,3 +1,4 @@
+import { RequestHeaders } from "../interfaces/IHttpProxy";
 import { concat } from "./ohttpHelpers";
 
 // --- RFC 9292 / QUIC-style varint encoder (1/2/4/8 bytes) ---
@@ -173,7 +174,7 @@ export function encodeIndeterminateLengthRequest(opts: {
 }
 
 // --- Convenience: build headers from a JS object (lowercases keys) ---
-export function headersFromObject(obj: Record<string, string | Uint8Array>): Array<[string, string | Uint8Array]> {
+export function headersFromObject(obj: RequestHeaders): Array<[string, string | Uint8Array]> {
 	if (obj) {
 		return Object.entries(obj).map(([k, v]) => [k.toLowerCase(), v]);
 	} else {

--- a/src/lib/utils/ohttpHelpers.ts
+++ b/src/lib/utils/ohttpHelpers.ts
@@ -2,6 +2,7 @@ import { CipherSuite, HkdfSha256, Aes128Gcm } from '@hpke/core'
 import { DhkemX25519HkdfSha256 } from '@hpke/dhkem-x25519'
 import axios from 'axios'
 import { decodeKnownLengthRequest, decodeKnownLengthResponse, encodeKnownLengthRequest, headersFromObject } from './bhttp';
+import { RequestHeaders } from '../interfaces/IHttpProxy';
 
 export type HpkeConfig = {
 	keyId: number;
@@ -18,7 +19,7 @@ type KeyConfig = { keyId: number; kemId: number; publicKey: Uint8Array; pairs: K
 export type HttpRequestParameters = {
 	method: "GET" | "POST",
 	url: string,
-	headers: Record<string, string | Uint8Array>,
+	headers: RequestHeaders,
 	body?: string | object
 }
 


### PR DESCRIPTION
Fixes this type checking error:

```
TypeCheckError: Type 'RequestHeaders' is not assignable to type 'Record<string, string | Uint8Array<ArrayBufferLike>>'.
  Index signature for type 'string' is missing in type 'RequestHeaders'.
 ❯ src/lib/services/HttpProxy/HttpProxy.ts:118:8
```