### PR TITLE
Fix presentation history of JPT credentials

### DIFF
--- a/src/context/CredentialsContext.ts
+++ b/src/context/CredentialsContext.ts
@@ -8,6 +8,7 @@ type WalletStateCredential = CurrentSchema.WalletStateCredential;
 
 type CredentialEngine = {
 	credentialParsingEngine: ParsingEngineI;
+	jptVerifier: CredentialVerifier;
 	sdJwtVerifier: CredentialVerifier;
 	msoMdocVerifier: CredentialVerifier;
 };

--- a/src/hooks/useFetchPresentations.js
+++ b/src/hooks/useFetchPresentations.js
@@ -67,6 +67,8 @@ const useFetchPresentations = (keystore, batchId = null, transactionId = null) =
 
 						const result = await (async () => {
 							switch (parsedCredential.metadata.credential.format) {
+								case VerifiableCredentialFormat.DC_JPT:
+									return credentialEngine.jptVerifier.verify({ rawCredential: presentation.data, opts: {} });
 								case VerifiableCredentialFormat.VC_SDJWT:
 									return credentialEngine.sdJwtVerifier.verify({ rawCredential: presentation.data, opts: {} });
 								case VerifiableCredentialFormat.DC_SDJWT:


### PR DESCRIPTION
The presentation history for JPT credentials is broken and shows an empty history, which is simply because the parser isn't set up.