### PR TITLE
Credential status indicators fix: Check that credential format is 'dc+jpt' before treating it as such

### DIFF
--- a/src/components/Credentials/CredentialStatusIndicatorsRibbon.tsx
+++ b/src/components/Credentials/CredentialStatusIndicatorsRibbon.tsx
@@ -37,7 +37,7 @@ function getCredentialStatusIndicators(vcEntity: ExtendedVcEntity, keypairs: Key
 			alg = parsedCred.issuerHeader.alg as string;
 		}
 
-		if (vcEntity.data) {
+		if (vcEntity.data && vcEntity.format === 'dc+jpt') {
 			const credParts = vcEntity.data.split('.');
 			const dpkJwk = JSON.parse(new TextDecoder().decode(fromBase64Url(credParts[credParts.length - 1].split('~')[1])));
 


### PR DESCRIPTION
Add a simple check to make sure that the credential that we're about to parse is actually of the correct type.

This fixes the following exception:
```node
hook.js:608 TypeError: Cannot read properties of undefined (reading 'replace')
    at fromBase64Url (util.ts:136:22)
    at getCredentialStatusIndicators (CredentialStatusIndicatorsRibbon.tsx:42:55)
    at CredentialStatusIndicatorsRibbon (CredentialStatusIndicatorsRibbon.tsx:149:47)
```
