### PR TITLE
Fix error handling in hardware key registration

### DIFF
--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -961,6 +961,7 @@ const Settings = () => {
 									},
 								});
 								retry = result.retry;
+								break;
 							}
 
 							case 'user-abort':

--- a/src/pages/Settings/Settings.tsx
+++ b/src/pages/Settings/Settings.tsx
@@ -16,7 +16,7 @@ import { byteArrayEquals, compareBy, toBase64Url } from '../../util';
 import { withAuthenticatorAttachmentFromHints } from '@/util-webauthn';
 import { formatDate } from '../../functions/DateFormat';
 import type { PrecreatedPublicKeyCredential, WebauthnPrfEncryptionKeyInfo, WebauthnSignArkgPublicSeed, WebauthnSignSplitBbsKeypair } from '../../services/keystore';
-import { isPrfKeyV2, serializePrivateData } from '../../services/keystore';
+import { isPrfKeyV2, parseWebauthnSignGeneratedKey, serializePrivateData } from '../../services/keystore';
 
 import Button from '../../components/Buttons/Button';
 import DeletePopup from '../../components/Popups/DeletePopup';
@@ -938,6 +938,11 @@ const Settings = () => {
 						const credential = await webauthnDialog.beginCreate(options, {
 							bodyText: t('registerHardwareKey.intro'),
 						});
+						const generatedKey = parseWebauthnSignGeneratedKey(credential);
+						if (!generatedKey) {
+							throw new Error('Key not found', { cause: { id: 'key-not-found' } });
+						}
+
 						const name = await webauthnDialog.input({
 							bodyText: t('registerHardwareKey.successGiveName'),
 							input: {

--- a/src/services/keystore.ts
+++ b/src/services/keystore.ts
@@ -1918,7 +1918,7 @@ export async function generateDeviceResponseWithProximity([privateData, mainKey,
 	return { deviceResponseMDoc };
 }
 
-function parseWebauthnSignGeneratedKey(credential: PublicKeyCredential | null)
+export function parseWebauthnSignGeneratedKey(credential: PublicKeyCredential | null)
 	: NewWebauthnSignKeypair | null {
 	const generatedKey = credential?.getClientExtensionResults()?.sign?.generatedKey;
 	if (generatedKey) {


### PR DESCRIPTION
Before, failure during registration of hardware keys was indicated as success in the dialog even though no hardware key was actually added.